### PR TITLE
Removed large warnings from compilation output

### DIFF
--- a/lib/sentinel/controllers/account_controller.ex
+++ b/lib/sentinel/controllers/account_controller.ex
@@ -2,8 +2,6 @@ defmodule Sentinel.Controllers.Account do
   use Phoenix.Controller
   use Guardian.Phoenix.Controller
 
-  alias Sentinel.AccountView
-  alias Sentinel.UserHelper
   alias Sentinel.ViewHelper
   alias Sentinel.Mailer
   alias Sentinel.Util
@@ -17,7 +15,7 @@ defmodule Sentinel.Controllers.Account do
   Get the account data for the current user
   Responds with status 200 and body view show JSON
   """
-  def show(conn, _params, current_user, claims \\ %{}) do
+  def show(conn, _params, current_user, _claims \\ %{}) do
     json conn, ViewHelper.user_view.render("show.json", %{user: current_user})
   end
 
@@ -27,7 +25,7 @@ defmodule Sentinel.Controllers.Account do
   The stored email address will only be updated after clicking the link in that message.
   Responds with status 200 and body "ok" if successfull.
   """
-  def update(conn, %{"account" => params}, current_user, claims) do
+  def update(conn, %{"account" => params}, current_user, _claims) do
     {confirmation_token, changeset} = current_user
                                       |> AccountUpdater.changeset(params)
     if changeset.valid? do

--- a/lib/sentinel/controllers/password_resets_controller.ex
+++ b/lib/sentinel/controllers/password_resets_controller.ex
@@ -15,7 +15,7 @@ defmodule Sentinel.Controllers.PasswordResets do
   Responds with status 200 and body "ok" if successfull.
   Responds with status 422 and body {errors: [messages]} otherwise.
   """
-  def create(conn, %{"email" => email}, headers \\ %{}, session \\ %{}) do
+  def create(conn, %{"email" => email}, _headers \\ %{}, _session \\ %{}) do
     user = UserHelper.find_by_email(email)
     {password_reset_token, changeset} = PasswordResetter.create_changeset(user)
 
@@ -38,7 +38,7 @@ defmodule Sentinel.Controllers.PasswordResets do
   Responds with status 200 and body {token: token} if successfull. Use this token in subsequent requests as authentication.
   Responds with status 422 and body {errors: [messages]} otherwise.
   """
-  def reset(conn, params = %{"user_id" => user_id}, headers \\%{}, session \\ %{}) do
+  def reset(conn, params = %{"user_id" => user_id}, _headers \\%{}, _session \\ %{}) do
     user = Util.repo.get(UserHelper.model, user_id)
     changeset = PasswordResetter.reset_changeset(user, params)
 
@@ -47,7 +47,7 @@ defmodule Sentinel.Controllers.PasswordResets do
       permissions = UserHelper.model.permissions(user.role)
 
       case Guardian.encode_and_sign(user, :token, permissions) do
-        { :ok, token, encoded_claims } -> json conn, %{token: token}
+        { :ok, token, _encoded_claims } -> json conn, %{token: token}
         { :error, :token_storage_failure } -> Util.send_error(conn, %{errors: "Failed to store session, please try to login again using your new password"})
         { :error, reason } -> Util.send_error(conn, %{errors: reason})
       end

--- a/lib/sentinel/controllers/sessions_controller.ex
+++ b/lib/sentinel/controllers/sessions_controller.ex
@@ -20,7 +20,7 @@ defmodule Sentinel.Controllers.Sessions do
         permissions = UserHelper.model.permissions(user.role)
 
         case Guardian.encode_and_sign(user, :token, permissions) do
-          { :ok, token, encoded_claims } -> json conn, %{token: token}
+          { :ok, token, _encoded_claims } -> json conn, %{token: token}
           { :error, :token_storage_failure } -> Util.send_error(conn, %{error: "Failed to store session, please try to login again using your new password"})
           { :error, reason } -> Util.send_error(conn, %{error: reason})
         end
@@ -35,7 +35,7 @@ defmodule Sentinel.Controllers.Sessions do
         permissions = UserHelper.model.permissions(user.role)
 
         case Guardian.encode_and_sign(user, :token, permissions) do
-          { :ok, token, encoded_claims } ->
+          { :ok, token, _encoded_claims } ->
             json conn, %{token: token}
           { :error, :token_storage_failure } -> Util.send_error(conn, %{error: "Failed to store session, please try to login again using your new password"})
           { :error, reason } -> Util.send_error(conn, %{error: reason})

--- a/lib/sentinel/controllers/users_controller.ex
+++ b/lib/sentinel/controllers/users_controller.ex
@@ -84,14 +84,14 @@ defmodule Sentinel.Controllers.Users do
         Mailer.send_welcome_email(user, confirmation_token)
         conn
         |> put_status(201)
-        |> json :ok
+        |> json(:ok)
       :false ->
         permissions = UserHelper.model.permissions(user.role)
 
         case Guardian.encode_and_sign(user, :token, permissions) do
           { :ok, token, _encoded_claims } -> conn
             |> put_status(201)
-            |> json %{token: token}
+            |> json(%{token: token})
           { :error, :token_storage_failure } -> Util.send_error(conn, %{error: "Failed to store session, please try to login again using your new password"})
           { :error, reason } -> Util.send_error(conn, %{error: reason})
         end
@@ -102,7 +102,7 @@ defmodule Sentinel.Controllers.Users do
         case Guardian.encode_and_sign(user, :token, permissions) do
           { :ok, token, _encoded_claims } -> conn
             |> put_status(201)
-            |> json %{token: token}
+            |> json(%{token: token})
           { :error, :token_storage_failure } -> Util.send_error(conn, %{error: "Failed to store session, please try to login again using your new password"})
           { :error, reason } -> Util.send_error(conn, %{error: reason})
         end


### PR DESCRIPTION
Not sure if these warnings are intentional but they're cluttering up the compilation output. I found them a bit annoying
