### PR TITLE
Passing User struct when creating changeset

### DIFF
--- a/lib/sentinel/controllers/html/users_controller.ex
+++ b/lib/sentinel/controllers/html/users_controller.ex
@@ -2,7 +2,7 @@ defmodule Sentinel.Controllers.Html.User do
   use Phoenix.Controller
 
   def new(conn, _params) do
-    changeset = Sentinel.UserHelper.model.changeset(%{})
+    changeset = Sentinel.UserHelper.model.changeset(struct(Sentinel.UserHelper.model))
 
     conn
     |> put_status(:ok)


### PR DESCRIPTION
This does not fail the tests, but when integrating sentinel on my app and going into the signup HTML controller, an error is raised: `no function clause matching in Ecto.Changeset.do_cast/4`

Not sure how to reproduce the error, but it started happening when I changed to the new `cast` with `validate_required` of [ecto 2](https://github.com/elixir-ecto/ecto/blob/master/CHANGELOG.md#revamped-changesets)
