### PR TITLE
Fixing status codes, params and some errors messages

### DIFF
--- a/lib/sentinel/controllers/html/sessions_controller.ex
+++ b/lib/sentinel/controllers/html/sessions_controller.ex
@@ -18,7 +18,7 @@ defmodule Sentinel.Controllers.Html.Sessions do
   Log in as an existing user.
   Parameter are "username" and "password".
   """
-  def create(conn, %{"session" => %{"username" => username, "password" => password}}) do
+  def create(conn, %{"session" => %{"username" => username, "password" => password}} = params) do
     case Authenticator.authenticate_by_username(username, password) do
       {:ok, user} ->
         conn
@@ -27,8 +27,9 @@ defmodule Sentinel.Controllers.Html.Sessions do
         |> redirect(to: "/")
       {:error, errors} ->
         conn
-        |> put_flash(:error, errors.base)
-        |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
+        |> put_flash(:error, "Unable to perform authentication")
+        |> put_status(:unauthorized)
+        |> render(Sentinel.SessionView, "new.html", changeset: error_changeset(params, errors))
     end
   end
 
@@ -36,7 +37,7 @@ defmodule Sentinel.Controllers.Html.Sessions do
   Log in as an existing user.
   Parameter are "email" and "password".
   """
-  def create(conn, %{"session" => %{"email" => email, "password" => password}}) do
+  def create(conn, %{"session" => %{"email" => email, "password" => password}} = params) do
     case Authenticator.authenticate_by_email(email, password) do
       {:ok, user} ->
         conn
@@ -45,8 +46,9 @@ defmodule Sentinel.Controllers.Html.Sessions do
         |> redirect(to: "/")
       {:error, errors} ->
         conn
-        |> put_flash(:error, errors.base)
-        |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
+        |> put_flash(:error, "Unable to perform authentication")
+        |> put_status(:unauthorized)
+        |> render(Sentinel.SessionView, "new.html", changeset: error_changeset(params, errors))
     end
   end
 
@@ -57,5 +59,13 @@ defmodule Sentinel.Controllers.Html.Sessions do
     Guardian.Plug.sign_out(conn)
     |> put_flash(:info, "Logged out successfully.")
     |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
+  end
+
+  defp error_changeset(params, errors) do
+    changeset = Sentinel.Session.changeset(%Sentinel.Session{}, params["session"])
+    changeset = Enum.reduce(errors, changeset,  fn ({key, value}, changeset) ->
+      Ecto.Changeset.add_error(changeset, key, value)
+    end)
+    %{changeset | action: :create}
   end
 end

--- a/lib/sentinel/controllers/html/sessions_controller.ex
+++ b/lib/sentinel/controllers/html/sessions_controller.ex
@@ -18,17 +18,16 @@ defmodule Sentinel.Controllers.Html.Sessions do
   Log in as an existing user.
   Parameter are "username" and "password".
   """
-  def create(conn, %{"username" => username, "password" => password}) do
+  def create(conn, %{"session" => %{"username" => username, "password" => password}}) do
     case Authenticator.authenticate_by_username(username, password) do
       {:ok, user} ->
         conn
         |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Successfully logged in")
         |> redirect(to: "/")
-      {:error, _errors} ->
+      {:error, errors} ->
         conn
-        |> put_flash(:error, "Unable to authenticate successfully")
-        |> put_status(:unauthorized)
+        |> put_flash(:error, errors.base)
         |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
     end
   end
@@ -37,17 +36,16 @@ defmodule Sentinel.Controllers.Html.Sessions do
   Log in as an existing user.
   Parameter are "email" and "password".
   """
-  def create(conn, %{"email" => email, "password" => password}) do
+  def create(conn, %{"session" => %{"email" => email, "password" => password}}) do
     case Authenticator.authenticate_by_email(email, password) do
       {:ok, user} ->
         conn
         |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Successfully logged in")
         |> redirect(to: "/")
-      {:error, _errors} ->
+      {:error, errors} ->
         conn
-        |> put_flash(:error, "Unable to authenticate successfully")
-        |> put_status(:unauthorized)
+        |> put_flash(:error, errors.base)
         |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
     end
   end

--- a/lib/sentinel/controllers/html/users_controller.ex
+++ b/lib/sentinel/controllers/html/users_controller.ex
@@ -5,8 +5,7 @@ defmodule Sentinel.Controllers.Html.User do
     changeset = Sentinel.UserHelper.model.changeset(struct(Sentinel.UserHelper.model))
 
     conn
-    |> put_status(:ok)
-    |> render(Sentinel.UserView, "new.html", changeset: changeset)
+    |> render(Sentinel.ViewHelper.user_view, "new.html", changeset: changeset)
   end
 
   @doc """
@@ -21,7 +20,7 @@ defmodule Sentinel.Controllers.Html.User do
         conn
         |> put_status(:unprocessable_entity)
         |> put_flash(:error, "Unable to complete the registration")
-        |> render(Sentinel.UserView, :new, changeset: changeset)
+        |> render(Sentinel.ViewHelper.user_view, :new, changeset: changeset)
     end
   end
 
@@ -30,25 +29,21 @@ defmodule Sentinel.Controllers.Html.User do
       {false, false} -> # not confirmable or invitable
         conn
         |> Guardian.Plug.sign_in(user)
-        |> put_status(:created)
         |> put_flash(:info, "Successfully logged in")
         |> redirect(to: "/")
       {_confirmable, :true} -> # must be invited
         conn
         |> Guardian.Plug.sign_in(user)
-        |> put_status(:created)
         |> put_flash(:info, "Successfully invited the user")
         |> redirect(to: Sentinel.RouterHelper.helpers.user_path(conn, :new))
       {:required, _invitable} -> # must be confirmed
         conn
         |> Guardian.Plug.sign_in(user)
-        |> put_status(:created)
         |> put_flash(:info, "Successfully created account. Please confirm your account")
         |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
       {_confirmable_default, _invitable} -> # default behavior, optional confirmable, not invitable
         conn
         |> Guardian.Plug.sign_in(user)
-        |> put_status(:created)
         |> put_flash(:info, "Successfully logged in. Please confirm your account")
         |> redirect(to: "/")
     end
@@ -69,7 +64,7 @@ defmodule Sentinel.Controllers.Html.User do
   def confirmation_instructions(conn, _params) do
     conn
     |> put_status(:ok)
-    |> render(Sentinel.UserView, "confirmation_instructions.html")
+    |> render(Sentinel.ViewHelper.user_view, "confirmation_instructions.html")
   end
 
   def confirm(conn, params) do
@@ -77,11 +72,9 @@ defmodule Sentinel.Controllers.Html.User do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Successfully confirmed your account")
-        |> put_status(:ok)
         |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
       {:error, _changeset} ->
         conn
-        |> put_status(:unprocessable_entity)
         |> put_flash(:error, "Unable to confirm your account")
         |> redirect(to: Sentinel.RouterHelper.helpers.user_path(conn, :confirmation_instructions))
     end
@@ -92,12 +85,10 @@ defmodule Sentinel.Controllers.Html.User do
       {:ok, user} ->
         conn
         |> Guardian.Plug.sign_in(user)
-        |> put_status(:created)
         |> put_flash(:info, "Successfully setup your account")
         |> redirect(to: Sentinel.RouterHelper.helpers.sessions_path(conn, :new))
       {:error, _changeset} ->
         conn
-        |> put_status(:unprocessable_entity)
         |> put_flash(:error, "Unable to setup your account")
         |> redirect(to: Sentinel.RouterHelper.helpers.user_path(:new))
     end

--- a/lib/sentinel/models/session.ex
+++ b/lib/sentinel/models/session.ex
@@ -8,7 +8,7 @@ defmodule Sentinel.Session do
     field :password, :string
   end
 
-  @required_fields ~w(password)
+  @required_fields ~w(password)a
   @optional_fields ~w(username email)
 
   @doc """
@@ -20,6 +20,7 @@ defmodule Sentinel.Session do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
     |> Sentinel.Session.username_or_email_required
   end
 

--- a/lib/sentinel/templates/session/new.html.eex
+++ b/lib/sentinel/templates/session/new.html.eex
@@ -4,17 +4,26 @@
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong with your email or password!</p>
+      <%= if error = @changeset.errors[:base] do %>
+        <%= content_tag :span, elem(error, 0), class: "sentinel help-block" %>
+      <% end %>
     </div>
   <% end %>
 
   <div class="sentinel form-group">
     <%= label f, :email, class: "sentinel control-label" %>
     <%= email_input f, :email, class: "sentinel form-control" %>
+    <% if error = @changeset.errors[:email] do %>
+      <%= content_tag :span, elem(error, 0), class: "sentinel help-block" %>
+    <% end %>
   </div>
 
   <div class="sentinel form-group">
     <%= label f, :password, class: "sentinel control-label" %>
     <%= password_input f, :password, class: "sentinel form-control" %>
+    <% if error = @changeset.errors[:password] do %>
+      <%= content_tag :span, elem(error, 0), class: "sentinel help-block" %>
+    <% end %>
   </div>
 
   <div class="sentinel actions form-group">

--- a/test/controller/html/confirmation_test.exs
+++ b/test/controller/html/confirmation_test.exs
@@ -37,7 +37,7 @@ defmodule Html.ConfirmationTest do
     user = Sentinel.Util.repo.insert!(changeset)
 
     conn = call(Sentinel.TestRouter, :post, "/users/confirm", %{email: user.email, confirmation_token: "bad_token"})
-    assert conn.status == 422
+    assert conn.status == 302
   end
 
   test "confirm a user" do
@@ -46,7 +46,7 @@ defmodule Html.ConfirmationTest do
     user = Sentinel.Util.repo.insert!(changeset)
 
     conn = call(Sentinel.TestRouter, :post, "/users/confirm", %{email: user.email, confirmation_token: token})
-    assert conn.status == 200
+    assert conn.status == 302
 
     updated_user = Sentinel.Util.repo.get! Sentinel.UserHelper.model, user.id
 
@@ -66,7 +66,7 @@ defmodule Html.ConfirmationTest do
     new_email_user = Sentinel.TestRepo.update!(changeset)
 
     conn = call(Sentinel.TestRouter, :post, "/users/confirm", %{email: new_email_user.email, confirmation_token: token})
-    assert conn.status == 200
+    assert conn.status == 302
 
     updated_user = Sentinel.Util.repo.get! Sentinel.UserHelper.model, user.id
     assert updated_user.hashed_confirmation_token == nil

--- a/test/controller/html/session_controller_test.exs
+++ b/test/controller/html/session_controller_test.exs
@@ -24,16 +24,20 @@ defmodule Html.SessionControllerTest do
   end
 
   test "sign in with unknown email" do
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: @email}})
     assert conn.status == 401
+    assert String.contains?(conn.resp_body, ~s(Oops, something went wrong with your email or password!))
+    assert String.contains?(conn.resp_body, ~s(Unknown email or password))
   end
 
   test "sign in with wrong password" do
     Registrator.changeset(%{email: @email, password: @password})
     |> repo.insert!
 
-    conn = call(TestRouter, :post, "/sessions", %{password: "wrong", email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: "wrong", email: @email}})
     assert conn.status == 401
+    assert String.contains?(conn.resp_body, ~s(Oops, something went wrong with your email or password!))
+    assert String.contains?(conn.resp_body, ~s(Unknown email or password))
   end
 
   test "sign in as unconfirmed user - confirmable default/optional" do
@@ -43,7 +47,7 @@ defmodule Html.SessionControllerTest do
                       |> Confirmator.confirmation_needed_changeset
     repo.insert!(changeset)
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: @email}})
     assert conn.status == 302
   end
 
@@ -54,7 +58,7 @@ defmodule Html.SessionControllerTest do
                       |> Confirmator.confirmation_needed_changeset
     repo.insert!(changeset)
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: @email}})
     assert conn.status == 302
   end
 
@@ -65,8 +69,10 @@ defmodule Html.SessionControllerTest do
                       |> Confirmator.confirmation_needed_changeset
     repo.insert!(changeset)
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: @email}})
     assert conn.status == 401
+    assert String.contains?(conn.resp_body, ~s(Oops, something went wrong with your email or password!))
+    assert String.contains?(conn.resp_body, ~s(Account not confirmed yet. Please follow the instructions we sent you by email.))
   end
 
   test "sign in as confirmed user with email" do
@@ -74,7 +80,7 @@ defmodule Html.SessionControllerTest do
                                       |> Ecto.Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
                                       |> repo.insert!
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: @email})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: @email}})
     assert conn.status == 302
   end
 
@@ -83,28 +89,32 @@ defmodule Html.SessionControllerTest do
                                       |> Ecto.Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
                                       |> repo.insert!
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, email: String.upcase(@odd_case_email)})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, email: String.upcase(@odd_case_email)}})
     assert conn.status == 302
   end
 
   test "sign in with unknown username" do
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, username: @username})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, username: @username}})
     assert conn.status == 401
+    assert String.contains?(conn.resp_body, ~s(Oops, something went wrong with your email or password!))
+    assert String.contains?(conn.resp_body, ~s(Unknown username or password))
   end
 
   test "sign in with username and wrong password" do
     Registrator.changeset(%{"username" => @username, "password" => @password, "role" => @role})
                                         |> repo.insert!
 
-    conn = call(TestRouter, :post, "/sessions", %{password: "wrong", username: @username})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: "wrong", username: @username}})
     assert conn.status == 401
+    assert String.contains?(conn.resp_body, ~s(Oops, something went wrong with your email or password!))
+    assert String.contains?(conn.resp_body, ~s(Unknown username or password))
   end
 
   test "sign in user with username" do
     Registrator.changeset(%{"username" => @username, "password" => @password, "role" => @role})
                                         |> repo.insert!
 
-    conn = call(TestRouter, :post, "/sessions", %{password: @password, username: @username})
+    conn = call(TestRouter, :post, "/sessions", %{session: %{password: @password, username: @username}})
     assert conn.status == 302
   end
 

--- a/test/controller/html/user_controller_test.exs
+++ b/test/controller/html/user_controller_test.exs
@@ -38,7 +38,7 @@ defmodule Html.UserControllerTest do
 
     with_mock Sentinel.Mailer, [:passthrough], [send_welcome_email: fn(_, _) -> mocked_mail end] do
       conn = call(TestRouter, :post, "/users", %{user: %{password: @password, email: @email}})
-      assert conn.status == 201
+      assert conn.status == 302
       assert conn.private.phoenix_flash == %{"info" => "Successfully logged in. Please confirm your account"}
 
       user = TestRepo.get_by!(User, email: @email)
@@ -60,7 +60,7 @@ defmodule Html.UserControllerTest do
 
     with_mock Sentinel.Mailer, [:passthrough], [send_welcome_email: fn(_, _) -> mocked_mail end] do
       conn = call(TestRouter, :post, "/users", %{user: %{password: @password, email: @email}})
-      assert conn.status == 201
+      assert conn.status == 302
       assert conn.private.phoenix_flash == %{"info" => "Successfully created account. Please confirm your account"}
 
       user = TestRepo.get_by!(User, email: @email)
@@ -78,7 +78,7 @@ defmodule Html.UserControllerTest do
     Config.persist([sentinel: [invitable: false]])
 
     conn = call(TestRouter, :post, "/users", %{user: %{password: @password, email: @email}})
-    assert conn.status == 201
+    assert conn.status == 302
     assert conn.private.phoenix_flash == %{"info" => "Successfully logged in"}
 
     user = TestRepo.get_by!(User, email: @email)
@@ -96,7 +96,7 @@ defmodule Html.UserControllerTest do
 
     with_mock Sentinel.Mailer, [:passthrough], [send_invite_email: fn(_, _) -> mocked_mail end] do
       conn = call(TestRouter, :post, "/users", %{user: %{email: @email}})
-      assert conn.status == 201
+      assert conn.status == 302
       assert conn.private.phoenix_flash == %{"info" => "Successfully invited the user"}
 
       assert mocked_mail.from == @from_email
@@ -116,7 +116,7 @@ defmodule Html.UserControllerTest do
 
     with_mock Sentinel.Mailer, [:passthrough], [send_invite_email: fn(_, _) -> mocked_mail end] do
       conn = call(TestRouter, :post, "/users", %{user: %{email: @email}})
-      assert conn.status == 201
+      assert conn.status == 302
       assert conn.private.phoenix_flash == %{"info" => "Successfully invited the user"}
 
       assert mocked_mail.from == @from_email
@@ -138,7 +138,7 @@ defmodule Html.UserControllerTest do
     user = repo.update!(changeset)
 
     conn = call(TestRouter, :post, "/users/#{user.id}/invited", %{confirmation_token: confirmation_token, password_reset_token: password_reset_token, password: @password})
-    assert conn.status == 201
+    assert conn.status == 302
     assert conn.private.phoenix_flash == %{"info" => "Successfully setup your account"}
 
     updated_user = repo.get! UserHelper.model, user.id

--- a/test/controller/json/session_controller_test.exs
+++ b/test/controller/json/session_controller_test.exs
@@ -97,7 +97,7 @@ defmodule Json.SessionControllerTest do
   test "sign in with unknown username" do
     conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
     assert conn.status == 401
-    assert conn.resp_body == Poison.encode!(%{errors: [%{base: "Unknown email or password"}]})
+    assert conn.resp_body == Poison.encode!(%{errors: [%{base: "Unknown username or password"}]})
   end
 
   test "sign in with username and wrong password" do
@@ -106,7 +106,7 @@ defmodule Json.SessionControllerTest do
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", username: @username}, @headers)
     assert conn.status == 401
-    assert conn.resp_body == Poison.encode!(%{errors: [%{base: "Unknown email or password"}]})
+    assert conn.resp_body == Poison.encode!(%{errors: [%{base: "Unknown username or password"}]})
   end
 
   test "sign in user with username" do


### PR DESCRIPTION
When using redirect the 302 status is only set if the status on the connection
is not already set.

The errors still need to be prettified (I assume there can be more than one
because of the map returned) but this is better than a cryptic message with
no indication of what went wrong
