### PR TITLE
Adding a debug log for the confirmation token

### DIFF
--- a/lib/sentinel/user_registration.ex
+++ b/lib/sentinel/user_registration.ex
@@ -1,4 +1,6 @@
 defmodule Sentinel.UserRegistration do
+  import Logger
+
   alias Sentinel.Registrator
   alias Sentinel.Confirmator
   alias Sentinel.Mailer
@@ -13,6 +15,8 @@ defmodule Sentinel.UserRegistration do
     {confirmation_token, changeset} =
       Registrator.changeset(user_params)
       |> Confirmator.confirmation_needed_changeset
+
+    Logger.debug "Confirmation token is: #{confirmation_token}"
 
     case Util.repo.insert(changeset) do
       {:ok, user} -> confirmable_and_invitable(user, confirmation_token)


### PR DESCRIPTION
In development if you need the confirmation token, you can only reach it
through the email, which more often than not is stored in memory.

This adds a simple way to use the code and since it's only on debug log level
it should never affect anything on production environments. Even if the production
log level is set to debug, the information is not as sensitive as a password
