### PR TITLE
Fixes file writes during sentinel.install and  makes writes raise in case of failure

### DIFF
--- a/lib/mix/tasks/install.ex
+++ b/lib/mix/tasks/install.ex
@@ -73,8 +73,8 @@ defmodule Mix.Tasks.Sentinel.Install do
       |> Enum.map(fn(line) -> line end)
       |> Enum.slice(21..100)
 
-    old_content ++ new_content
-    |> File.write(user_path)
+    user_path
+    |> File.write!(old_content ++ new_content)
   end
 
   defp create_guardian_token_migration do
@@ -108,8 +108,8 @@ defmodule Mix.Tasks.Sentinel.Install do
       |> Enum.map(fn(line) -> line end)
       |> Enum.slice(3..100)
 
-    migration_content ++ new_content
-    |> File.write(migration_path)
+    migration_path
+    |> File.write!(migration_content ++ new_content)
   end
 
   defp create_ueberauth_migration do
@@ -143,7 +143,7 @@ defmodule Mix.Tasks.Sentinel.Install do
       |> Enum.map(fn(line) -> line end)
       |> Enum.slice(3..100)
 
-    migration_content ++ new_content
-    |> File.write(migration_path)
+    migration_path  
+    |> File.write!(migration_content ++ new_content)
   end
 end


### PR DESCRIPTION
Hello! I was debugging this since yesterday and finally found the cause to be trivial but almost invisible. :-)
 I have replaced File.write/2 with File.write!/2 so that that failures are explicit for the user.