### PR TITLE
Add ability to generate and copy views and templates into the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,25 @@ URL, with the following params:
 If you want to customize the routes, or use your own controller
 endpoints you can do that by overriding the individual routes listed.
 
+### Generate custom views
+If you want to use custom views, you'll need copy over the views and templates
+to your application. Sentinel provides a mix task make this a one-liner:
+
+```shell
+mix sentinel.gen.views
+```
+
+This mix task accepts a single argument of the specific context. This value can
+be "email", "error", "password", "session", "shared", or "user". Once you copy
+over a context's view and templates, you must update the config to point to
+your application's local files:
+
+```json
+config :sentinel, views: %{user: MyApp.Web.UserView}
+```
+
+The keys for this views config map correspond with the list of contexts above.
+
 ### Auth Error Handler
 If you'd like to write your own custom authorization or authentication
 handler change the `auth_handler` Sentinel configuration option

--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ config :sentinel,
   ecto_repos: [Sentinel.TestRepo],
   auth_handler: Sentinel.AuthHandler,
   layout_view: MyApp.Layout, # your layout
-  layout_view: :app,
-  user_view: Sentinel.UserView,
-  error_view: Sentinel.ErrorView,
+  layout: :app,
+  views: %{
+    email: Sentinel.EmailView, # your email view (optional)
+    error: Sentinel.ErrorView, # your error view (optional)
+    password: Sentinel.PasswordView, # your password view (optional)
+    session: Sentinel.SessionView, # your session view (optional)
+    shared: Sentinel.SharedView, # your shared view (optional)
+    user: Sentinel.UserView # your user view (optional)
+  },
   router: Sentinel.TestRouter, # your router
   endpoint: Sentinel.Endpoint, # your endpoint
   invitable: true,

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,6 @@ config :comeonin, :bcrypt_log_rounds, 4
 config :sentinel,
   crypto_provider: Comeonin.Bcrypt,
   auth_handler: Sentinel.AuthHandler,
-  user_view: Sentinel.UserView
 
 config :guardian, Guardian,
   allowed_algos: ["HS512"], # optional

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,7 @@ config :comeonin, :bcrypt_log_rounds, 4
 
 config :sentinel,
   crypto_provider: Comeonin.Bcrypt,
-  auth_handler: Sentinel.AuthHandler,
+  auth_handler: Sentinel.AuthHandler
 
 config :guardian, Guardian,
   allowed_algos: ["HS512"], # optional
@@ -26,7 +26,7 @@ config :guardian, Guardian,
   verify_issuer: true, # optional
   serializer: Sentinel.GuardianSerializer,
   hooks: GuardianDb,
-  permissions: Application.get_env(:sentinel, :permissions)#,
+  permissions: Application.get_env(:sentinel, :permissions)
 
 config :guardian_db, GuardianDb,
   repo: Application.get_env(:sentinel, :repo)
@@ -43,7 +43,7 @@ config :ueberauth, Ueberauth,
       [
         param_nesting: "user",
         callback_methods: ["POST"],
-        uid_field: :email,
+        uid_field: :email
       ]
     },
   ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,6 @@ config :sentinel,
   crypto_provider: Comeonin.Bcrypt,
   unauthorized_handler: Sentinel.AuthHandler,
   repo: Sentinel.TestRepo,
-  user_view: Sentinel.UserView,
   environment: :test,
   send_emails: true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,8 +35,14 @@ config :sentinel,
   repo: Sentinel.TestRepo, #FIXME should be your repo
   ecto_repos: [Sentinel.TestRepo],
   auth_handler: Sentinel.AuthHandler,
-  user_view: Sentinel.UserView,
-  error_view: Sentinel.ErrorView,
+  views: %{
+    email: Sentinel.EmailView, # your email view (optional)
+    error: Sentinel.ErrorView, # your error view (optional)
+    password: Sentinel.PasswordView, # your password view (optional)
+    session: Sentinel.SessionView, # your session view (optional)
+    shared: Sentinel.SharedView, # your shared view (optional)
+    user: Sentinel.UserView # your user view (optional)
+  },
   router: Sentinel.TestRouter, #FIXME your router
   endpoint: Sentinel.Endpoint, #FIXME your endpoint
   invitable: true,

--- a/lib/mix/tasks/generate_views.ex
+++ b/lib/mix/tasks/generate_views.ex
@@ -23,6 +23,17 @@ defmodule Mix.Tasks.Sentinel.GenerateViews do
 
     Mix.Phoenix.copy_from paths(), "lib/sentinel/web/templates", "", binding,
       template_files(templates_path, binding[:singular])
+
+   Mix.shell.info """
+
+    Update config.exs to set your custom views:
+
+        config :sentinel,
+          views: %{
+            session: MyApp.Web.SessionView,
+            user: MyApp.Web.UserView
+          }
+    """
   end
 
   @spec raise_with_help() :: no_return()

--- a/lib/mix/tasks/generate_views.ex
+++ b/lib/mix/tasks/generate_views.ex
@@ -1,0 +1,100 @@
+defmodule Mix.Tasks.Sentinel.GenerateViews do
+  @moduledoc """
+  Used to generate sentinel views for customization
+  """
+  @shortdoc "Used to copy and configure sentinel views"
+
+  use Mix.Task
+
+  def run(args) do
+    view_name = validate_arg!(args)
+    view_module = view_module(view_name)
+
+    views_path = Mix.Phoenix.web_path("views")
+    templates_path = Mix.Phoenix.web_path("templates")
+    binding = Mix.Phoenix.inflect(view_module)
+    binding = Keyword.put(binding, :module, "#{binding[:web_module]}.#{binding[:scoped]}")
+
+    Mix.Phoenix.check_module_name_availability!(binding[:module])
+
+    Mix.Phoenix.copy_from paths(), "priv/templates/views", "", binding, [
+      {:eex, "#{binding[:singular]}_template.ex", Path.join(views_path, "#{binding[:path]}.ex")}
+    ]
+
+    Mix.Phoenix.copy_from paths(), "lib/sentinel/web/templates", "", binding,
+      template_files(templates_path, binding[:singular])
+  end
+
+  @spec raise_with_help() :: no_return()
+  defp raise_with_help do
+    Mix.raise """
+    mix sentinel.gen.views expects just the view name:
+        mix sentinel.gen.views user
+
+    Valid values are "email", "error", "password", "session", "shared", "user"
+    """
+  end
+
+  defp validate_arg!([arg] = args) do
+    if length(args) == 1 && Enum.find(valid_values, fn(x) -> x == arg end) do
+      arg
+    else
+      raise_with_help()
+    end
+  end
+
+  defp valid_values do
+    ["email", "error", "password", "session", "shared", "user"]
+  end
+
+  defp view_module(name) when is_binary(name) do
+    name
+    |> String.downcase
+    |> String.trim_trailing("view")
+    |> String.capitalize
+    |> Kernel.<>("View")
+  end
+  defp view_module(name), do: view_module(to_string(name))
+
+  defp paths do
+    Mix.Phoenix.generator_paths() ++ ["deps/sentinel", :sentinel]
+  end
+
+  defp template_files(templates_path, "email_view") do
+    [
+      {:text, "email/invite.html.eex", Path.join(templates_path, "email/invite.html.eex")},
+      {:text, "email/invite.text.eex", Path.join(templates_path, "email/invite.text.eex")},
+      {:text, "email/new_email_address.html.eex", Path.join(templates_path, "email/new_email_address.html.eex")},
+      {:text, "email/new_email_address.text.eex", Path.join(templates_path, "email/new_email_address.text.eex")},
+      {:text, "email/password_reset.html.eex", Path.join(templates_path, "email/password_reset.html.eex")},
+      {:text, "email/password_reset.text.eex", Path.join(templates_path, "email/password_reset.text.eex")},
+      {:text, "email/welcome.html.eex", Path.join(templates_path, "email/welcome.html.eex")},
+      {:text, "email/welcome.text.eex", Path.join(templates_path, "email/welcome.text.eex")}
+    ]
+  end
+  defp template_files(templates_path, "password_view") do
+    [
+      {:text, "password/edit.html.eex", Path.join(templates_path, "password/edit.html.eex")},
+      {:text, "password/new.html.eex", Path.join(templates_path, "password/new.html.eex")}
+    ]
+  end
+  defp template_files(templates_path, "session_view") do
+    [
+      {:text, "session/new.html.eex", Path.join(templates_path, "session/new.html.eex")}
+    ]
+  end
+  defp template_files(templates_path, "shared_view") do
+    [
+      {:text, "shared/links.html.eex", Path.join(templates_path, "shared/links.html.eex")}
+    ]
+  end
+  defp template_files(templates_path, "user_view") do
+    [
+      {:text, "user/confirmation_instructions.html.eex", Path.join(templates_path, "user/confirmation_instructions.html.eex")},
+      {:text, "user/edit.html.eex", Path.join(templates_path, "user/edit.html.eex")},
+      {:text, "user/invitation_registration.html.eex", Path.join(templates_path, "user/invitation_registration.html.eex")},
+      {:text, "user/new.html.eex", Path.join(templates_path, "user/new.html.eex")}
+    ]
+  end
+  defp template_files(templates_path, _), do: []
+end

--- a/lib/mix/tasks/sentinel.gen.views.ex
+++ b/lib/mix/tasks/sentinel.gen.views.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.Sentinel.Gen.Views do
   @moduledoc """
   Used to generate sentinel views for customization
   """
-  @shortdoc "Used to copy and configure sentinel views"
 
   use Mix.Task
 
@@ -14,6 +13,7 @@ defmodule Mix.Tasks.Sentinel.Gen.Views do
     templates_path = Mix.Phoenix.web_path("templates")
     binding = Mix.Phoenix.inflect(view_module)
     binding = Keyword.put(binding, :module, "#{binding[:web_module]}.#{binding[:scoped]}")
+    binding = Keyword.put(binding, :templates_path, templates_path)
 
     Mix.Phoenix.check_module_name_availability!(binding[:module])
 

--- a/lib/mix/tasks/sentinel.gen.views.ex
+++ b/lib/mix/tasks/sentinel.gen.views.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Sentinel.GenerateViews do
+defmodule Mix.Tasks.Sentinel.Gen.Views do
   @moduledoc """
   Used to generate sentinel views for customization
   """

--- a/lib/sentinel/config.ex
+++ b/lib/sentinel/config.ex
@@ -46,13 +46,6 @@ defmodule Sentinel.Config do
   end
 
   @doc """
-  Wrapper for getting the application config of :error_view
-  """
-  def error_view do
-    Application.get_env(:sentinel, :error_view, Sentinel.ErrorView)
-  end
-
-  @doc """
   Wrapper for getting the application config of :invitable
   """
   def invitable do
@@ -182,18 +175,41 @@ defmodule Sentinel.Config do
     Application.get_env(:sentinel, :user_model_validator)
   end
 
+  ### View configs
+  #
   @doc """
-  Wrapper for getting the application config of :user_view
+  Wrapper for getting the application config of :layout_view
   """
-  def user_view do
-    Application.get_env(:sentinel, :user_view, Sentinel.UserView)
-  end
-
   def layout_view do
     Application.get_env(:sentinel, :layout_view, Sentinel.LayoutView)
   end
 
+  @doc """
+  Wrapper for getting the application config of :layout
+  """
   def layout do
     Application.get_env(:sentinel, :layout, :app)
+  end
+
+  @doc """
+  Wrapper for getting and merging the application config of :views
+  """
+  def views do
+    Map.merge(default_views(), custom_views())
+  end
+
+  defp default_views do
+    %{
+      email: Sentinel.EmailView,
+      error: Sentinel.ErrorView,
+      password: Sentinel.PasswordView,
+      session: Sentinel.SessionView,
+      shared: Sentinel.SharedView,
+      user: Sentinel.UserView
+    }
+  end
+
+  defp custom_views do
+    Application.get_env(:sentinel, :views, %{})
   end
 end

--- a/lib/sentinel/mailer/mailer.ex
+++ b/lib/sentinel/mailer/mailer.ex
@@ -1,6 +1,6 @@
 defmodule Sentinel.Mailer do
   use Bamboo.Mailer, otp_app: :sentinel
-  use Bamboo.Phoenix, view: Sentinel.EmailView
+  use Bamboo.Phoenix, view: Sentinel.Config.views.email
 
   alias Sentinel.Mailer
 

--- a/lib/sentinel/web/auth_handler.ex
+++ b/lib/sentinel/web/auth_handler.ex
@@ -20,7 +20,7 @@ defmodule Sentinel.AuthHandler do
     conn
     |> put_status(401)
     |> put_flash(:error, "Failed to authenticate")
-    |> render(Sentinel.SessionView, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
+    |> render(Config.views.session, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
   end
 
   @doc """

--- a/lib/sentinel/web/auth_handler.ex
+++ b/lib/sentinel/web/auth_handler.ex
@@ -30,6 +30,6 @@ defmodule Sentinel.AuthHandler do
     Util.send_error(conn, %{base: "Unknown email or password"}, 403)
   end
   def unauthorized(conn, _) do
-    render(conn, Config.error_view, "403.html", %{conn: conn})
+    render(conn, Config.views.error, "403.html", %{conn: conn})
   end
 end

--- a/lib/sentinel/web/controllers/html/account_controller.ex
+++ b/lib/sentinel/web/controllers/html/account_controller.ex
@@ -19,7 +19,7 @@ defmodule Sentinel.Controllers.Html.AccountController do
   """
   def edit(conn, _params, current_user, _claims \\ %{}) do
     changeset = Config.user_model.changeset(current_user, %{})
-    render(conn, Config.user_view, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
+    render(conn, Config.views.user, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
   end
 
   @doc """
@@ -35,12 +35,12 @@ defmodule Sentinel.Controllers.Html.AccountController do
 
         conn
         |> put_flash(:info, "Successfully updated user account")
-        |> render(Config.user_view, "edit.html", %{conn: conn, user: updated_user, changeset: new_changeset})
+        |> render(Config.views.user, "edit.html", %{conn: conn, user: updated_user, changeset: new_changeset})
       {:error, changeset} ->
         conn
         |> put_status(422)
         |> put_flash(:error, "Failed to update user account")
-        |> render(Config.user_view, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
+        |> render(Config.views.user, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
     end
   end
 end

--- a/lib/sentinel/web/controllers/html/auth_controller.ex
+++ b/lib/sentinel/web/controllers/html/auth_controller.ex
@@ -16,7 +16,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
 
   def request(conn, _params) do
     changeset = Sentinel.Session.changeset(%Sentinel.Session{})
-    render(conn, Sentinel.SessionView, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
+    render(conn, Config.views.session, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
   end
 
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
@@ -37,7 +37,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
     conn
     |> put_status(401)
     |> put_flash(:error, "Failed to authenticate")
-    |> render(Sentinel.SessionView, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
+    |> render(Config.views.session, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
   end
 
   defp new_user(conn, user, confirmation_token) do

--- a/lib/sentinel/web/controllers/html/password_controller.ex
+++ b/lib/sentinel/web/controllers/html/password_controller.ex
@@ -15,7 +15,7 @@ defmodule Sentinel.Controllers.Html.PasswordController do
   plug Guardian.Plug.LoadResource when action in [:authenticated_update]
 
   def new(conn, _params, _headers \\ %{}, _session \\ %{}) do
-    render(conn, Sentinel.PasswordView, "new.html", %{conn: conn})
+    render(conn, Config.views.password, "new.html", %{conn: conn})
   end
 
   def create(conn, %{"password" => %{"email" => email}}, _headers \\ %{}, _session \\ %{}) do # FIXME could extract all of this here, and on json side into another module
@@ -52,7 +52,7 @@ defmodule Sentinel.Controllers.Html.PasswordController do
 
   def edit(conn, params, headers \\ %{}, session \\ %{})
   def edit(conn, %{"user_id" => user_id, "password_reset_token" => password_reset_token}, _headers, _session) do
-    render(conn, Sentinel.PasswordView, "edit.html", %{conn: conn, password_reset_token: password_reset_token, user_id: user_id})
+    render(conn, Config.views.password, "edit.html", %{conn: conn, password_reset_token: password_reset_token, user_id: user_id})
   end
   def edit(conn, _params, _headers, _session) do
     conn
@@ -106,7 +106,7 @@ defmodule Sentinel.Controllers.Html.PasswordController do
         |> put_flash(:info, "Update successful")
         |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
       {:error, changeset} ->
-        render(conn, Sentinel.AccountView, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
+        render(conn, Config.views.password, "edit.html", %{conn: conn, user: current_user, changeset: changeset})
     end
   end
 end

--- a/lib/sentinel/web/controllers/html/user_controller.ex
+++ b/lib/sentinel/web/controllers/html/user_controller.ex
@@ -13,7 +13,7 @@ defmodule Sentinel.Controllers.Html.UserController do
   end
 
   def confirmation_instructions(conn, _params) do
-    render(conn, Sentinel.UserView, "confirmation_instructions.html", %{conn: conn})
+    render(conn, Config.views.user, "confirmation_instructions.html", %{conn: conn})
   end
   def resend_confirmation_instructions(conn, params) do
     Sentinel.Confirm.send_confirmation_instructions(params)

--- a/lib/sentinel/web/controllers/html/user_controller.ex
+++ b/lib/sentinel/web/controllers/html/user_controller.ex
@@ -9,7 +9,7 @@ defmodule Sentinel.Controllers.Html.UserController do
 
   def new(conn, _params) do
     changeset = Config.user_model.changeset(struct(Config.user_model), %{})
-    render(conn, Sentinel.UserView, "new.html", %{conn: conn, changeset: changeset})
+    render(conn, Config.views.user, "new.html", %{conn: conn, changeset: changeset})
   end
 
   def confirmation_instructions(conn, _params) do
@@ -49,7 +49,7 @@ defmodule Sentinel.Controllers.Html.UserController do
       |> Config.repo.get(id)
       |> Config.user_model.changeset(%{})
 
-    render(conn, Sentinel.UserView, "invitation_registration.html", %{
+    render(conn, Config.views.user, "invitation_registration.html", %{
       conn: conn,
       changeset: changeset,
       user_id: id,
@@ -75,7 +75,7 @@ defmodule Sentinel.Controllers.Html.UserController do
         conn
         |> put_status(422)
         |> put_flash(:error, "Failed to create user")
-        |> render(Sentinel.SessionView, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
+        |> render(Config.views.session, "new.html", %{conn: conn, changeset: changeset, providers: Config.ueberauth_providers})
     end
   end
 end

--- a/lib/sentinel/web/controllers/json/account_controller.ex
+++ b/lib/sentinel/web/controllers/json/account_controller.ex
@@ -19,7 +19,7 @@ defmodule Sentinel.Controllers.Json.AccountController do
   Responds with status 200 and body view show JSON
   """
   def show(conn, _params, current_user, _claims \\ %{}) do
-    json conn, Config.user_view.render("show.json", %{user: current_user})
+    json conn, Config.views.user.render("show.json", %{user: current_user})
   end
 
   @doc """
@@ -32,7 +32,7 @@ defmodule Sentinel.Controllers.Json.AccountController do
     case Update.update(current_user, params) do
       {:ok, %{user: updated_user, auth: _auth, confirmation_token: confirmation_token}} ->
         Update.maybe_send_new_email_address_confirmation_email(updated_user, confirmation_token)
-        json conn, Config.user_view.render("show.json", %{user: updated_user})
+        json conn, Config.views.user.render("show.json", %{user: updated_user})
       {:error, changeset} ->
         Util.send_error(conn, changeset.errors)
     end

--- a/lib/sentinel/web/controllers/json/auth_controller.ex
+++ b/lib/sentinel/web/controllers/json/auth_controller.ex
@@ -38,7 +38,7 @@ defmodule Sentinel.Controllers.Json.AuthController do
 
     conn
     |> put_status(201)
-    |> json(Config.user_view.render("show.json", %{user: user}))
+    |> json(Config.views.user.render("show.json", %{user: user}))
   end
 
   defp existing_user(conn, user) do

--- a/lib/sentinel/web/controllers/json/password_controller.ex
+++ b/lib/sentinel/web/controllers/json/password_controller.ex
@@ -88,7 +88,7 @@ defmodule Sentinel.Controllers.Json.PasswordController do
 
     case Config.repo.update(changeset) do
       {:ok, _updated_auth} ->
-        json conn, Config.user_view.render("show.json", %{user: user})
+        json conn, Config.views.user.render("show.json", %{user: user})
       {:error, changeset} ->
         Util.send_error(conn, changeset.errors)
     end

--- a/lib/sentinel/web/controllers/json/user_controller.ex
+++ b/lib/sentinel/web/controllers/json/user_controller.ex
@@ -42,7 +42,7 @@ defmodule Sentinel.Controllers.Json.UserController do
       {:ok, user} ->
         conn
         |> put_status(200)
-        |> render(Config.user_view, "show.json", %{user: user})
+        |> render(Config.views.user, "show.json", %{user: user})
       {:error, changeset} -> Util.send_error(conn, changeset.errors)
     end
   end

--- a/lib/sentinel/web/templates/password/edit.html.eex
+++ b/lib/sentinel/web/templates/password/edit.html.eex
@@ -19,4 +19,4 @@
   </div>
 <% end %>
 
-<%= render(Sentinel.SharedView, "links.html", assigns) %>
+<%= render(Sentinel.Config.views.shared, "links.html", assigns) %>

--- a/lib/sentinel/web/templates/password/new.html.eex
+++ b/lib/sentinel/web/templates/password/new.html.eex
@@ -13,4 +13,4 @@
   </div>
 <% end %>
 
-<%= render(Sentinel.SharedView, "links.html", assigns) %>
+<%= render(Sentinel.Config.views.shared, "links.html", assigns) %>

--- a/lib/sentinel/web/templates/session/new.html.eex
+++ b/lib/sentinel/web/templates/session/new.html.eex
@@ -33,4 +33,4 @@
   </ul>
 <% end %>
 
-<%= render Sentinel.SharedView, "links.html", assigns %>
+<%= render Sentinel.Config.views.shared, "links.html", assigns %>

--- a/lib/sentinel/web/templates/user/confirmation_instructions.html.eex
+++ b/lib/sentinel/web/templates/user/confirmation_instructions.html.eex
@@ -11,4 +11,4 @@
   </div>
 <% end %>
 
-<%= render(Sentinel.SharedView, "links.html", assigns) %>
+<%= render(Sentinel.Config.views.shared, "links.html", assigns) %>

--- a/lib/sentinel/web/templates/user/new.html.eex
+++ b/lib/sentinel/web/templates/user/new.html.eex
@@ -33,4 +33,4 @@
   </div>
 <% end %>
 
-<%= render(Sentinel.SharedView, "links.html", assigns) %>
+<%= render(Sentinel.Config.views.shared, "links.html", assigns) %>

--- a/lib/sentinel/web/views/user_view.ex
+++ b/lib/sentinel/web/views/user_view.ex
@@ -25,6 +25,6 @@ defmodule Sentinel.UserView do
   end
 
   defp user_view do
-    Config.user_view
+    Config.views.user
   end
 end

--- a/priv/templates/views/email_view_template.ex
+++ b/priv/templates/views/email_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %> do
-  use Phoenix.View, namespace: Bamboo.EmailView
+  use Phoenix.View, root: "<%= templates_path %>", namespace: Bamboo.EmailView
   use Phoenix.HTML
 
   alias Sentinel.Config

--- a/priv/templates/views/email_view_template.ex
+++ b/priv/templates/views/email_view_template.ex
@@ -1,0 +1,6 @@
+defmodule <%= module %> do
+  use Phoenix.View, namespace: Bamboo.EmailView
+  use Phoenix.HTML
+
+  alias Sentinel.Config
+end

--- a/priv/templates/views/error_view_template.ex
+++ b/priv/templates/views/error_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %> do
-  use Phoenix.View
+  use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 
   def render("404.html", _assigns) do

--- a/priv/templates/views/error_view_template.ex
+++ b/priv/templates/views/error_view_template.ex
@@ -1,0 +1,18 @@
+defmodule <%= module %> do
+  use Phoenix.View
+  use Phoenix.HTML
+
+  def render("404.html", _assigns) do
+    "Page not found"
+  end
+
+  def render("500.html", _assigns) do
+    "Server internal error"
+  end
+
+  # In case no render clause matches or no
+  # template is found, let's render it as 500
+  def template_not_found(_template, assigns) do
+    render "500.html", assigns
+  end
+end

--- a/priv/templates/views/password_view_template.ex
+++ b/priv/templates/views/password_view_template.ex
@@ -1,4 +1,4 @@
-defmodule <%= inspect module %> do
+defmodule <%= module %> do
   use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 

--- a/priv/templates/views/password_view_template.ex
+++ b/priv/templates/views/password_view_template.ex
@@ -1,0 +1,6 @@
+defmodule <%= inspect module %> do
+  use Phoenix.View
+  use Phoenix.HTML
+
+  alias Sentinel.Config
+end

--- a/priv/templates/views/password_view_template.ex
+++ b/priv/templates/views/password_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= inspect module %> do
-  use Phoenix.View
+  use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 
   alias Sentinel.Config

--- a/priv/templates/views/session_view_template.ex
+++ b/priv/templates/views/session_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %> do
-  use Phoenix.View
+  use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 
   alias Sentinel.Config

--- a/priv/templates/views/session_view_template.ex
+++ b/priv/templates/views/session_view_template.ex
@@ -1,0 +1,6 @@
+defmodule <%= module %> do
+  use Phoenix.View
+  use Phoenix.HTML
+
+  alias Sentinel.Config
+end

--- a/priv/templates/views/shared_view_template.ex
+++ b/priv/templates/views/shared_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %> do
-  use Phoenix.View
+  use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 
   alias Sentinel.Config

--- a/priv/templates/views/shared_view_template.ex
+++ b/priv/templates/views/shared_view_template.ex
@@ -1,0 +1,6 @@
+defmodule <%= module %> do
+  use Phoenix.View
+  use Phoenix.HTML
+
+  alias Sentinel.Config
+end

--- a/priv/templates/views/user_view_template.ex
+++ b/priv/templates/views/user_view_template.ex
@@ -1,5 +1,5 @@
 defmodule <%= module %> do
-  use Phoenix.View
+  use Phoenix.View, root: "<%= templates_path %>"
   use Phoenix.HTML
 
   alias Sentinel.Config

--- a/priv/templates/views/user_view_template.ex
+++ b/priv/templates/views/user_view_template.ex
@@ -1,0 +1,30 @@
+defmodule <%= module %> do
+  use Phoenix.View
+  use Phoenix.HTML
+
+  alias Sentinel.Config
+
+  def render("index.json", %{users: users}) do
+    render_many(users, user_view, "user.json")
+  end
+
+  def render("show.json", %{user: user, token: token}) do
+    %{data: %{token: token, user: render_one(user, user_view, "user.json")}}
+  end
+  def render("show.json", %{user: user}) do
+    render_one(user, user_view, "user.json")
+  end
+
+  def render("user.json", %{user: user}) do
+    %{id: user.id,
+      email: user.email,
+      role: user.role,
+      hashed_confirmation_token: user.hashed_confirmation_token,
+      confirmed_at: user.confirmed_at,
+      unconfirmed_email: user.unconfirmed_email}
+  end
+
+  defp user_view do
+    Config.views.user
+  end
+end


### PR DESCRIPTION
I had a need to customize the default registration views (by adding additional user fields) and needed a way to copy the views/templates into my application as a result.

This copies sentinel views and templates into the application for a given context using `mix sentinel.gen.views user`. Available values are "email", "error", "password", "session", "shared", and "user". To support this, all views have been parameterized and added to `Config.views`. Once a given view (and templates) has been copied to the application, the view must be specified in `config.exs` using the `views` key:

```elixir
config :sentinel,
  views: %{user: MyApp.Web.UserView}
```