### PR TITLE
Pass original request parameters back through to the user model validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ config :sentinel,
   confirmable: :optional,
   confirmable_redirect_url: "http://localhost:4000", # for api usage only
   password_reset_url: "http://localhost:4000", # for api usage only
-  send_emails: true
+  send_emails: true,
+  user_model_validator: {MyApp.Accounts, :custom_changeset} # your custom validator
 ```
 
 See `config/test.exs` for an example of configuring Sentinel
@@ -283,6 +284,26 @@ to the module name of your handler.
 It must define two functions, `unauthorized/2`, and `unauthenticated/2`,
 where the first parameter is the connection, and the second is
 information about the session.
+
+### Custom model validator
+If you want to add custom changeset validations to the user model, you can do
+that by specifying a user model validator: 
+
+```json
+config :sentinel, user_model_validator: {MyApp.Accounts, :custom_changeset}
+```
+This function must accept 2 arguments consisting of a changeset and a map of
+params and *must* return a changeset. The params in the second argument will be
+the raw params from the original request (not the ueberauth callback params).
+
+```elixir
+def custom_changeset(changeset, attrs \\ %{}) do
+  changeset
+  |> cast(attrs, [:my_attr])
+  |> validate_required([:my_attr])
+  |> validate_inclusion(:my_attr, ["foo", "bar"])
+end
+```
 
 ## Contributing/Want something new?
 Create an issue. Preferably with a PR. If you're super awesome

--- a/lib/sentinel/helpers/user_helper.ex
+++ b/lib/sentinel/helpers/user_helper.ex
@@ -14,10 +14,10 @@ defmodule Sentinel.UserHelper do
   @doc """
   Adds extra validator specified in configuration
   """
-  def validator(changeset, params) do
+  def validator(changeset, params \\ %{}) do
     apply_validator(Config.user_model_validator, changeset, params)
   end
-  defp apply_validator(nil, changeset, params), do: changeset
+  defp apply_validator(nil, changeset, _params), do: changeset
   defp apply_validator({mod, fun}, changeset, params), do: apply(mod, fun, [changeset, params])
   defp apply_validator(validator, changeset, params) do
     validator.(changeset, params)

--- a/lib/sentinel/helpers/user_helper.ex
+++ b/lib/sentinel/helpers/user_helper.ex
@@ -14,12 +14,12 @@ defmodule Sentinel.UserHelper do
   @doc """
   Adds extra validator specified in configuration
   """
-  def validator(changeset) do
-    apply_validator(Config.user_model_validator, changeset)
+  def validator(changeset, params) do
+    apply_validator(Config.user_model_validator, changeset, params)
   end
-  defp apply_validator(nil, changeset), do: changeset
-  defp apply_validator({mod, fun}, changeset), do: apply(mod, fun, [changeset])
-  defp apply_validator(validator, changeset) do
-    validator.(changeset)
+  defp apply_validator(nil, changeset, params), do: changeset
+  defp apply_validator({mod, fun}, changeset, params), do: apply(mod, fun, [changeset, params])
+  defp apply_validator(validator, changeset, params) do
+    validator.(changeset, params)
   end
 end

--- a/lib/sentinel/ueberauthenticator.ex
+++ b/lib/sentinel/ueberauthenticator.ex
@@ -105,7 +105,7 @@ defmodule Sentinel.Ueberauthenticator do
       {confirmation_token, changeset} =
         updated_auth.info
         |> Map.from_struct
-        |> Registrator.changeset
+        |> Registrator.changeset(updated_auth.extra.raw_info)
         |> Confirmator.confirmation_needed_changeset
 
       user =

--- a/test/controllers/html/account_controller_test.exs
+++ b/test/controllers/html/account_controller_test.exs
@@ -90,11 +90,13 @@ defmodule Html.AccountControllerTest do
   end
 
   test "update account with custom validations", %{conn: conn, user: user, auth: auth} do
-    Application.put_env(:sentinel, :user_model_validator, fn changeset ->
+    params = %{account: %{password: @new_password}}
+  
+    Application.put_env(:sentinel, :user_model_validator, fn (changeset, params) ->
       Changeset.add_error(changeset, :password, "too_short")
     end)
 
-    conn = put conn, account_path(conn, :update), %{account: %{password: @new_password}}
+    conn = put conn, account_path(conn, :update), params
     response(conn, 422)
 
     assert String.contains?(conn.resp_body, "Failed to update user account")

--- a/test/controllers/html/user_controller_test.exs
+++ b/test/controllers/html/user_controller_test.exs
@@ -199,7 +199,7 @@ defmodule Html.UserControllerTest do
     Config.persist([sentinel: [confirmable: :optional]])
     Config.persist([sentinel: [invitable: false]])
 
-    Application.put_env(:sentinel, :user_model_validator, fn changeset ->
+    Application.put_env(:sentinel, :user_model_validator, fn (changeset, params) ->
       Ecto.Changeset.add_error(changeset, :password, "too short")
     end)
 

--- a/test/controllers/json/account_controller_test.exs
+++ b/test/controllers/json/account_controller_test.exs
@@ -88,11 +88,13 @@ defmodule Json.AccountControllerTest do
   end
 
   test "update account with custom validations", %{conn: conn, user: user, auth: auth} do
-    Application.put_env(:sentinel, :user_model_validator, fn changeset ->
+    params = %{account: %{password: @new_password}}
+
+    Application.put_env(:sentinel, :user_model_validator, fn (changeset, params) ->
       Changeset.add_error(changeset, :password, "too_short")
     end)
 
-    conn = put conn, api_account_path(conn, :update), %{account: %{password: @new_password}}
+    conn = put conn, api_account_path(conn, :update), params
     response = json_response(conn, 422)
     assert response == %{"errors" => [%{"password" => "too_short"}]}
     {:ok, _} = Ueberauthenticator.ueberauthenticate(%Ueberauth.Auth{

--- a/test/controllers/json/user_controller_test.exs
+++ b/test/controllers/json/user_controller_test.exs
@@ -201,7 +201,7 @@ defmodule Json.UserControllerTest do
     Config.persist([sentinel: [confirmable: :optional]])
     Config.persist([sentinel: [invitable: false]])
 
-    Application.put_env(:sentinel, :user_model_validator, fn changeset ->
+    Application.put_env(:sentinel, :user_model_validator, fn (changeset, params) ->
       Ecto.Changeset.add_error(changeset, :password, "too short")
     end)
 

--- a/test/support/sentinel_user.exs
+++ b/test/support/sentinel_user.exs
@@ -8,6 +8,7 @@ defmodule Sentinel.User do
     field  :hashed_confirmation_token,   :string
     field  :confirmed_at,                Ecto.DateTime
     field  :unconfirmed_email,           :string
+    field  :my_attr,                     :string, virtual: true
   end
 
   @required_fields [:email]

--- a/test/support/validator.ex
+++ b/test/support/validator.ex
@@ -1,0 +1,10 @@
+defmodule Sentinel.TestValidator do
+  import Ecto.Changeset
+
+  def custom_changeset(changeset, attrs \\ %{}) do
+    changeset
+    |> cast(attrs, [:my_attr])
+    |> validate_required([:my_attr])
+    |> validate_inclusion(:my_attr, ["foo", "bar"])
+  end
+end

--- a/test/unit/changeset/registrator_test.exs
+++ b/test/unit/changeset/registrator_test.exs
@@ -38,7 +38,7 @@ defmodule RegistratorTest do
   end
 
   test "changeset runs user_model_validator from config" do
-    Application.put_env(:sentinel, :user_model_validator, fn changeset ->
+    Application.put_env(:sentinel, :user_model_validator, fn (changeset, %{}) ->
       Ecto.Changeset.add_error(changeset, :email, "custom_error")
     end)
     changeset = Registrator.changeset(@valid_params)

--- a/test/unit/changeset/registrator_test.exs
+++ b/test/unit/changeset/registrator_test.exs
@@ -46,4 +46,13 @@ defmodule RegistratorTest do
     assert !changeset.valid?
     assert changeset.errors[:email] == {"custom_error", []}
   end
+
+  test "changeset runs with a custom user_model_validator module function" do
+    Application.put_env(:sentinel, :user_model_validator, {Sentinel.TestValidator, :custom_changeset})
+
+    changeset = Registrator.changeset(@valid_params)
+
+    assert !changeset.valid?
+    assert changeset.errors[:my_attr] == {"can't be blank", [validation: :required]}
+  end
 end


### PR DESCRIPTION
When using a `user_model_validator`, the passed in changeset only included parameters from the resulting ueberauth callback. This PR creates a passthrough of the original request parameters (prior to ueberauth) so that `user_model_validator` can do additional changeset casting and validation outside of ueberauth's requirements.

I am using this to add additional parameters to the user model via registration (like account type, name, etc.).