### PR TITLE
RFC: Add ability to use UUID primary keys

### DIFF
--- a/lib/sentinel/models/ueberauth.ex
+++ b/lib/sentinel/models/ueberauth.ex
@@ -10,6 +10,11 @@ defmodule Sentinel.Ueberauth do
   alias Sentinel.Config
   alias Sentinel.Changeset.HashPassword
 
+  if Application.get_env(:sentinel, :uuid_primary_keys, false) do
+    @primary_key {:id, :binary_id, autogenerate: true}
+    @foreign_key_type :binary_id
+  end
+
   schema "ueberauths" do
     field :provider, :string
     field :uid, :string


### PR DESCRIPTION
Opening this as an RFC since it's scratching a very specific itch of mine. This is using a hidden configuration option (`:uuid_primary_keys`) which in addition to modifying the generated `users` and `accounts` migrations allows me to use UUID primary keys with sentinel. Mainly interested in if you'd entertain this as an option and if so, is it OK being a hidden configuration or if you'd rather it be formally documented?