### PR TITLE
Add ability to define custom redirects via config

### DIFF
--- a/lib/sentinel/config.ex
+++ b/lib/sentinel/config.ex
@@ -203,4 +203,35 @@ defmodule Sentinel.Config do
   def registrator_callback do
     Application.get_env(:sentinel, :registrator_callback)
   end
+
+  @doc """
+  Wrapper for getting the application config of :redirects
+  """
+  def redirects do
+    Map.merge(default_redirects(), custom_redirects())
+  end
+
+  defp default_redirects do
+    %{
+      password_create: "/",
+      password_update: {:account, :edit},
+      password_update_error: "/",
+      password_update_unsuccessful: {:password, :new},
+      session_create: {:account, :edit},
+      session_create_error: {:auth, :new},
+      session_delete: "/",
+      user_confirmation: "/",
+      user_confirmation_error: "/",
+      user_confirmation_sent: "/",
+      user_create: {:account, :edit},
+      user_create_unconfirmed: "/",
+      user_invitation: {:account, :edit},
+      user_invitation_error: "/",
+      user_invited: {:user, :new},
+    }
+  end
+
+  defp custom_redirects do
+    Application.get_env(:sentinel, :redirects, %{})
+  end
 end

--- a/lib/sentinel/config.ex
+++ b/lib/sentinel/config.ex
@@ -63,7 +63,7 @@ defmodule Sentinel.Config do
   Helper method ensuring invitable is properly configured
   """
   def invitable_configured? do
-    invitable && invitation_registration_url
+    invitable() && invitation_registration_url()
   end
 
   @doc """
@@ -91,7 +91,7 @@ defmodule Sentinel.Config do
   Wrapper for getting the application config of :reply_to, defaults to the send_address
   """
   def reply_to do
-    Application.get_env(:sentinel, :reply_to, send_address)
+    Application.get_env(:sentinel, :reply_to, send_address())
   end
 
   @doc """
@@ -112,14 +112,14 @@ defmodule Sentinel.Config do
   Wrapper for getting the application config of :router_helper
   """
   def router_helper do
-    Module.concat(router, Helpers)
+    Module.concat(router(), Helpers)
   end
 
   @doc """
   Helper method ensuring router helper is properly configured
   """
   def router_helper_configured? do
-    router && endpoint
+    router() && endpoint()
   end
 
   @doc """
@@ -152,7 +152,7 @@ defmodule Sentinel.Config do
     end)
     |> Enum.map(fn provider_config ->
       {provider, _details} = provider_config
-      {Atom.to_string(provider), router_helper.auth_url(endpoint, :request, provider)}
+      {Atom.to_string(provider), router_helper().auth_url(endpoint(), :request, provider)}
     end)
   end
 

--- a/lib/sentinel/helpers/redirect_helper.ex
+++ b/lib/sentinel/helpers/redirect_helper.ex
@@ -1,0 +1,28 @@
+defmodule Sentinel.RedirectHelper do
+  @moduledoc """
+  Redirect helper for Sentinel
+  """
+
+  use Phoenix.Controller
+
+  alias Sentinel.Config
+
+  @doc """
+  Redirect from a given context
+  """
+  def redirect_from(conn, context) do
+    with {controller, action} <- Config.redirects()[context],
+         path                 <- get_path(controller, action) do
+      conn
+      |> redirect(to: path)
+    else
+      _ ->
+        conn
+        |> redirect(to: "/")
+    end
+  end
+
+  defp get_path(controller, action) do
+    apply(Config.router_helper(), :"#{controller}_path", [Config.endpoint, action])
+  end
+end

--- a/lib/sentinel/web/controllers/html/auth_controller.ex
+++ b/lib/sentinel/web/controllers/html/auth_controller.ex
@@ -6,6 +6,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
   use Phoenix.Controller
   alias Sentinel.AfterRegistrator
   alias Sentinel.Config
+  alias Sentinel.RedirectHelper
   alias Sentinel.RegistratorHelper
   alias Sentinel.Ueberauthenticator
 
@@ -49,23 +50,23 @@ defmodule Sentinel.Controllers.Html.AuthController do
       if ueberauth.provider == "identity" && is_nil(ueberauth.hashed_password) do
         conn
         |> put_flash(:info, "Successfully invited user")
-        |> redirect(to: Config.router_helper.user_path(Config.endpoint, :new))
+        |> RedirectHelper.redirect_from(:user_invited)
       else
         case Config.confirmable do
           :required ->
             conn
             |> put_flash(:info, "You must confirm your account to continue. You will receive an email with instructions for how to confirm your email address in a few minutes.")
-            |> redirect(to: "/")
+            |> RedirectHelper.redirect_from(:user_create_unconfirmed)
           :false ->
             conn
             |> Guardian.Plug.sign_in(user)
             |> put_flash(:info, "Signed up")
-            |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
+            |> RedirectHelper.redirect_from(:user_create)
           _ ->
             conn
             |> Guardian.Plug.sign_in(user)
             |> put_flash(:info, "You will receive an email with instructions for how to confirm your email address in a few minutes.")
-            |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
+            |> RedirectHelper.redirect_from(:user_create)
         end
       end
     end
@@ -75,7 +76,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
     conn
     |> Guardian.Plug.sign_in(user)
     |> put_flash(:info, "Logged in")
-    |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
+    |> RedirectHelper.redirect_from(:session_create)
   end
 
   @doc """
@@ -86,7 +87,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
     conn
     |> Guardian.Plug.sign_out
     |> put_flash(:info, "Logged out successfully.")
-    |> redirect(to: "/")
+    |> RedirectHelper.redirect_from(:session_delete)
   end
 
   @doc """
@@ -108,11 +109,11 @@ defmodule Sentinel.Controllers.Html.AuthController do
         conn
         |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Logged in")
-        |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
+        |> RedirectHelper.redirect_from(:session_create)
       {:error, _errors} ->
         conn
         |> put_flash(:error, "Unknown username or password")
-        |> redirect(to: Config.router_helper.auth_path(Config.endpoint, :new))
+        |> RedirectHelper.redirect_from(:session_create_error)
     end
   end
 end

--- a/lib/sentinel/web/controllers/html/user_controller.ex
+++ b/lib/sentinel/web/controllers/html/user_controller.ex
@@ -4,6 +4,7 @@ defmodule Sentinel.Controllers.Html.UserController do
   """
   use Phoenix.Controller
   alias Sentinel.Config
+  alias Sentinel.RedirectHelper
 
   plug :put_layout, {Config.layout_view, Config.layout}
 
@@ -20,7 +21,7 @@ defmodule Sentinel.Controllers.Html.UserController do
 
     conn
     |> put_flash(:info, "Sent confirmation instructions")
-    |> redirect(to: "/")
+    |> RedirectHelper.redirect_from(:user_confirmation_sent)
   end
 
   @doc """
@@ -34,12 +35,12 @@ defmodule Sentinel.Controllers.Html.UserController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Successfully confirmed your account")
-        |> redirect(to: "/")
+        |> RedirectHelper.redirect_from(:user_confirmation)
       {:error, _changeset} ->
         conn
         |> put_status(422)
         |> put_flash(:error, "Unable to confirm your account")
-        |> redirect(to: "/")
+        |> RedirectHelper.redirect_from(:user_confirmation_error)
     end
   end
 
@@ -61,7 +62,7 @@ defmodule Sentinel.Controllers.Html.UserController do
     conn
     |> put_status(422)
     |> put_flash(:error, "Invalid invitation tokens")
-    |> redirect(to: "/")
+    |> RedirectHelper.redirect_from(:user_invitation_error)
   end
 
   def invited(conn, params) do
@@ -70,7 +71,7 @@ defmodule Sentinel.Controllers.Html.UserController do
         conn
         |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Signed up")
-        |> redirect(to: Config.router_helper.account_path(Config.endpoint, :edit))
+        |> RedirectHelper.redirect_from(:user_invitation)
       {:error, changeset} ->
         conn
         |> put_status(422)


### PR DESCRIPTION
Allow any HTML action resulting in a redirect to be customized/overridden via config settings. The default list of redirect options are defined below. These redirect values can be a tuple representing `{:controller, :action}` or a binary string of the exact path.

```elixir
# default redirect values
config :sentinel,
  redirects: %{
      password_create: "/",
      password_update: {:account, :edit},
      password_update_error: "/",
      password_update_unsuccessful: {:password, :new},
      session_create: {:account, :edit},
      session_create_error: {:auth, :new},
      session_delete: "/",
      user_confirmation: "/",
      user_confirmation_error: "/",
      user_confirmation_sent: "/",
      user_create: {:account, :edit},
      user_create_unconfirmed: "/",
      user_invitation: {:account, :edit},
      user_invitation_error: "/",
      user_invited: {:user, :new},
  }
```

Would really appreciate your thoughts on this general approach/style. It was definitely influenced by `coherence`'s approach to redirects (https://github.com/smpallen99/coherence/blob/master/lib/coherence/redirects.ex) but more inline with sentinel's config/helper idioms. I can tidy anything up as needed and update the README with usage instructions but wanted your initial opinion prior to doing so. 🏄