### PR TITLE
Sign in when confirming email

### DIFF
--- a/lib/sentinel/web/controllers/html/user_controller.ex
+++ b/lib/sentinel/web/controllers/html/user_controller.ex
@@ -31,8 +31,9 @@ defmodule Sentinel.Controllers.Html.UserController do
   """
   def confirm(conn, params) do
     case Sentinel.Confirm.do_confirm(params) do
-      {:ok, _user} ->
+      {:ok, user} ->
         conn
+        |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Successfully confirmed your account")
         |> redirect(to: "/")
       {:error, _changeset} ->

--- a/test/controllers/html/user_controller_test.exs
+++ b/test/controllers/html/user_controller_test.exs
@@ -264,6 +264,7 @@ defmodule Html.UserControllerTest do
     assert updated_user.email == "new@example.com"
     assert String.contains?(conn.private.phoenix_flash["info"], "Successfully confirmed your account")
     assert String.contains?(conn.resp_body, "You are being <a href=\"/\">redirected</a>")
+    assert Guardian.Plug.current_resource(conn).id == updated_user.id
   end
 
   test "sign up with a custom registrator callback", %{conn: conn, params: params} do

--- a/test/controllers/html/user_controller_test.exs
+++ b/test/controllers/html/user_controller_test.exs
@@ -67,6 +67,7 @@ defmodule Html.UserControllerTest do
       assert_delivered_email mocked_mail
       assert String.contains?(conn.private.phoenix_flash["info"], "You will receive an email with instructions for how to confirm your email address in a few minutes.")
       assert String.contains?(conn.resp_body, Sentinel.Config.router_helper.account_path(Sentinel.Config.endpoint, :edit))
+      assert Guardian.Plug.current_resource(conn).id == user.id
     end
   end
 
@@ -83,6 +84,7 @@ defmodule Html.UserControllerTest do
       refute is_nil(user.hashed_confirmation_token)
       assert_delivered_email mocked_mail
       assert String.contains?(conn.private.phoenix_flash["info"], "You must confirm your account to continue. You will receive an email with instructions for how to confirm your email address in a few minutes.")
+      assert Guardian.Plug.current_resource(conn) == nil
     end
   end
 
@@ -98,6 +100,7 @@ defmodule Html.UserControllerTest do
     refute_delivered_email Sentinel.Mailer.NewEmailAddress.build(user, "token")
     assert String.contains?(conn.private.phoenix_flash["info"], "Signed up")
     assert String.contains?(conn.resp_body, Sentinel.Config.router_helper.account_path(Sentinel.Config.endpoint, :edit))
+    assert Guardian.Plug.current_resource(conn).id == user.id
   end
 
   test "inviting a user via the invitable sign up", %{conn: conn, invite_params: params, invite_email: mocked_mail} do # green
@@ -238,6 +241,7 @@ defmodule Html.UserControllerTest do
     assert updated_user.confirmed_at != nil
     assert String.contains?(conn.private.phoenix_flash["info"], "Successfully confirmed your account")
     assert String.contains?(conn.resp_body, "You are being <a href=\"/\">redirected</a>")
+    assert Guardian.Plug.current_resource(conn).id == updated_user.id
   end
 
   test "confirm a user's new email", %{conn: conn, params: %{user: user}} do
@@ -278,5 +282,6 @@ defmodule Html.UserControllerTest do
     user = TestRepo.get_by!(User, email: params.user.email)
 
     assert user.role == "foo"
+    assert Guardian.Plug.current_resource(conn).id == user.id
   end
 end


### PR DESCRIPTION
Currently, when successfully confirming an email, you are then prompted to sign in again. I believe it is more idiomatic to sign the user in automatically in the case of email confirmation. This PR makes that change and updates specs for all sign in methods to ensure session resource is being set appropriately. The destination path for this auto sign-in behavior can be controlled via the `redirects` config being introduced here: https://github.com/britton-jb/sentinel/pull/44