### PR TITLE
Add catch alls for error cases in confirm, auth_controller, and user_controller

### DIFF
--- a/lib/sentinel/confirm.ex
+++ b/lib/sentinel/confirm.ex
@@ -31,4 +31,5 @@ defmodule Sentinel.Confirm do
     |> Confirmator.confirmation_changeset
     |> Config.repo.update
   end
+  def do_confirm(_), do: {:error, :bad_request}
 end

--- a/lib/sentinel/web/controllers/html/auth_controller.ex
+++ b/lib/sentinel/web/controllers/html/auth_controller.ex
@@ -33,6 +33,7 @@ defmodule Sentinel.Controllers.Html.AuthController do
         failed_to_authenticate(conn)
     end
   end
+  def callback(conn, _params), do: failed_to_authenticate(conn)
 
   defp failed_to_authenticate(conn) do
     changeset = Sentinel.Session.changeset(%Sentinel.Session{})

--- a/lib/sentinel/web/controllers/html/user_controller.ex
+++ b/lib/sentinel/web/controllers/html/user_controller.ex
@@ -37,6 +37,9 @@ defmodule Sentinel.Controllers.Html.UserController do
         |> Guardian.Plug.sign_in(user)
         |> put_flash(:info, "Successfully confirmed your account")
         |> RedirectHelper.redirect_from(:user_confirmation)
+      {:error, :bad_request} ->
+        conn
+        |> RedirectHelper.redirect_from(:user_confirmation_error)
       {:error, _changeset} ->
         conn
         |> put_status(422)


### PR DESCRIPTION
I ran into these unhandled edge cases by using bad params when integration testing my app using sentinel. 