### PR TITLE
Adds the ability to persist oauth token data as embedded struct

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,12 @@ This is more notes about things that I'd like to change.
 ## Features
 Dialyzer - run it
 
-Ueberauthenticator `create_user_and_auth` registerable AND invitable fix on line 111 (FIXME)
-https://github.com/britton-jb/sentinel/issues/55
-https://github.com/britton-jb/sentinel/issues/37
-https://github.com/britton-jb/sentinel/issues/48
+- allow users to persist random stuff to user or auth record from the ueberauth struct
+  via a custom injected method? (like the avatar etc from github)
+- Ueberauthenticator `create_user_and_auth` registerable AND invitable fix on line 105 (FIXME)
+- https://github.com/britton-jb/sentinel/issues/55
+- https://github.com/britton-jb/sentinel/issues/37
+- https://github.com/britton-jb/sentinel/issues/48
 
 Params nesting per readme?
 Null warning per readme?

--- a/lib/sentinel/schema/ueberauth.ex
+++ b/lib/sentinel/schema/ueberauth.ex
@@ -15,15 +15,28 @@ defmodule Sentinel.Ueberauth do
   end
 
   schema "ueberauths" do
-    field :provider, :string
-    field :uid, :string
-    field :expires_at, :utc_datetime
+    # both
+    field :provider, :string, null: false
+    field :uid, :string, null: false
+    belongs_to :user, Config.user_model
+
+    # other
+    embeds_one :credentials, Credentials do
+      field :token, :string
+      field :refresh_token, :string
+      field :token_type, :string
+      field :secret, :string
+      field :expires, :boolean
+      field :expires_at, :utc_datetime
+      field :scopes, {:array, :string}
+    end
+
+    # identity
     field :hashed_password, :string
     field :hashed_password_reset_token, :string
     field :failed_attempts, :integer
     field :locked_at, :utc_datetime
     field :unlock_token, :string
-    belongs_to :user, Config.user_model
 
     timestamps()
   end
@@ -46,10 +59,21 @@ defmodule Sentinel.Ueberauth do
     updated_params = coerce_provider_to_string(params)
 
     struct
-    |> cast(updated_params, [:provider, :uid, :expires_at, :user_id])
+    |> cast(updated_params, [:provider, :uid, :user_id])
     |> validate_required([:provider, :uid, :user_id])
     |> validates_provider_doesnt_already_exist_for_user
     |> assoc_constraint(:user)
+    |> cast_embed(:credentials, with: &credentials_changeset/2)
+  end
+
+  defp credentials_changeset(struct, params) do
+    if params == %{} || is_nil(params.credentials) do
+      %Ecto.Changeset{}
+    else
+      struct
+      |> cast(params, [:token, :refresh_token, :token_type, :secret, :expires, :expires_at, :scopes])
+      |> validate_required([:token, :token_type])
+    end
   end
 
   @spec increment_failed_attempts(%Sentinel.Ueberauth{}) :: %Sentinel.Ueberauth{}
@@ -89,7 +113,7 @@ defmodule Sentinel.Ueberauth do
 
   defp identity_changeset(struct, params) do
     struct
-    |> cast(params, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id, :failed_attempts, :locked_at, :unlock_token])
+    |> cast(params, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id, :failed_attempts, :locked_at, :unlock_token])
     |> validate_required([:provider, :uid, :user_id])
     |> assoc_constraint(:user)
     |> validates_provider_doesnt_already_exist_for_user

--- a/priv/templates/migrations/ueberauth_migration_template.ex
+++ b/priv/templates/migrations/ueberauth_migration_template.ex
@@ -3,19 +3,25 @@ defmodule UeberauthMigration do
 
   def change do
     create table(:ueberauths) do
-      add :provider, :string
-      add :uid, :string
-      add :expires_at, :utc_datetime
+      add :provider, :string, null: false
+      add :uid, :string, null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+
+      # identity
       add :hashed_password, :text
       add :hashed_password_reset_token, :text
-      add :user_id, references(:users, on_delete: :delete_all)
       add :failed_attempts, :integer, default: 0
       add :locked_at, :utc_datetime
       add :unlock_token, :string
+
+      # ueberauth
+      add :credentials, :map
+
       timestamps()
     end
 
     create index(:ueberauths, [:user_id])
     create index(:ueberauths, [:uid])
+    create index(:ueberauths, [:user_id, :provider], unique: true)
   end
 end

--- a/test/support/migrations/ueberauth_migration.exs
+++ b/test/support/migrations/ueberauth_migration.exs
@@ -3,18 +3,25 @@ defmodule UeberauthMigration do
 
   def change do
     create table(:ueberauths) do
-      add :provider, :string
-      add :uid, :string
-      add :expires_at, :utc_datetime
+      add :provider, :string, null: false
+      add :uid, :string, null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+
+      # identity
       add :hashed_password, :text
       add :hashed_password_reset_token, :text
-      add :user_id, :integer
       add :failed_attempts, :integer, default: 0
       add :locked_at, :utc_datetime
       add :unlock_token, :string
+
+      # ueberauth
+      add :credentials, :map
+
       timestamps()
     end
 
     create index(:ueberauths, [:user_id])
+    create index(:ueberauths, [:uid])
+    create index(:ueberauths, [:user_id, :provider], unique: true)
   end
 end

--- a/test/unit/changeset/hash_password_test.exs
+++ b/test/unit/changeset/hash_password_test.exs
@@ -44,14 +44,14 @@ defmodule HashPasswordTest do
 
   test "it should return a valid changeset with a hashed password when password and confirmation are present and match", %{matching: params} do
     assert %Sentinel.Ueberauth{}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
 
   test "it should return an invalid changeset without a hashed password when password and confirmation are present and match, and errors are already present", %{matching: params} do
     refute %Sentinel.Ueberauth{}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> Ecto.Changeset.add_error(:misc, "doesn't matter what this is")
       |> HashPassword.changeset(params)
       |> Map.get(:changes)
@@ -62,14 +62,14 @@ defmodule HashPasswordTest do
     Config.persist([sentinel: [invitable: false ]])
 
     refute %Sentinel.Ueberauth{}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
 
   test "on update it should return a valid changeset when password and password confirmation do not match", %{mismatch: params} do
     assert %Sentinel.Ueberauth{id: 1}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
@@ -78,7 +78,7 @@ defmodule HashPasswordTest do
     Config.persist([sentinel: [invitable: true]])
 
     assert %Sentinel.Ueberauth{}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
@@ -87,21 +87,21 @@ defmodule HashPasswordTest do
     Config.persist([sentinel: [invitable: false]])
 
     refute %Sentinel.Ueberauth{}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
 
   test "on update it should return an invalid changest when password is absent an ueberauth struct", %{no_confirmation: params} do
     refute %Sentinel.Ueberauth{id: 1}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end
 
   test "it should return a valid changeset if changes are unrelated to password", %{no_password: params} do
     assert %Sentinel.Ueberauth{id: 1}
-      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :expires_at, :hashed_password, :hashed_password_reset_token, :user_id])
+      |> Ecto.Changeset.cast(%{}, [:provider, :uid, :hashed_password, :hashed_password_reset_token, :user_id])
       |> HashPassword.changeset(params)
       |> Map.get(:valid?)
   end

--- a/test/unit/changeset/password_resetter_test.exs
+++ b/test/unit/changeset/password_resetter_test.exs
@@ -67,7 +67,6 @@ defmodule PasswordResetterTest do
     hashed_password = "$2b$04$zx78eyMSingslyg5Q8Ay4.1qkrWkIFVKT8XUFBDJPpu2WH.2uBaGq"
 
     auth = %Sentinel.Ueberauth{
-      expires_at: nil,
       hashed_password: hashed_password,
       hashed_password_reset_token: "$2b$04$89K4euxPq3T3eYPLPZN7luYIf9jx4iwGvevEKLt17IGuSy4EvtKvK",
       id: 2421,


### PR DESCRIPTION
Previously Ueberauth functionality only allowed for logging in. This patch ensure the oauth token is persisted as an embedded struct on the `Sentinel.Ueberauth` schema. This allows for easy retrieval and usage of the other APIs the oauth token provides access to.